### PR TITLE
feat: add app-mode build variant for minimum eBPF overhead

### DIFF
--- a/goleash/Makefile
+++ b/goleash/Makefile
@@ -35,4 +35,4 @@ sys-enforce: all
 clean:
 	@echo "Cleaning up..."
 	rm -f $(HEADER_FILE) $(BPF_LOADER)
-	rm -rf *.o ebpf_*
+	rm -rf *.o ebpf_* ebpfapp_*

--- a/goleash/backend.c
+++ b/goleash/backend.c
@@ -113,8 +113,10 @@ int trace_exit(struct trace_event_raw_sched_process_template *ctx) {
     }
 
     bpf_map_delete_elem(&tracked_pids_map, &tgid);
+#ifndef GOLEASH_APP_MODE
     bpf_map_delete_elem(&temp_stack_ids, &tgid);
     bpf_map_delete_elem(&temp_exec_paths, &tgid);
+#endif
     return 0;
 }
 
@@ -136,6 +138,46 @@ int trace_syscall_enter(struct trace_event_raw_sys_enter *ctx) {
         return 0;
 
     long syscall_id = BPF_CORE_READ(ctx, id);
+
+#ifdef GOLEASH_APP_MODE
+    // -----------------------------------------------------------------------
+    // APP-MODE HOT PATH — minimum overhead.
+    // -----------------------------------------------------------------------
+    // No stack capture, no callsite pre-filter, no execve special-casing.
+    // Dedup on (tgid, syscall_id) so each pair is admitted at most once;
+    // every subsequent identical syscall short-circuits at the lookup below.
+    struct app_seen_key ask = {
+        .tgid       = current_pid,
+        .syscall_id = (u32)syscall_id,
+    };
+    if (bpf_map_lookup_elem(&app_seen, &ask))
+        return 0;
+    u8 one = 1;
+    bpf_map_update_elem(&app_seen, &ask, &one, BPF_ANY);
+
+    // Cold path: a (tgid, syscall_id) pair we have not admitted before.
+    {
+        u32 k = 2;
+        u64 *c = bpf_map_lookup_elem(&probe_stats, &k);
+        if (c) __sync_fetch_and_add(c, 1);
+    }
+
+    struct event *e = bpf_ringbuf_reserve(&events, sizeof(struct event), 0);
+    if (!e) {
+        u32 drop_key = 0;
+        u64 *drops = bpf_map_lookup_elem(&probe_stats, &drop_key);
+        if (drops) __sync_fetch_and_add(drops, 1);
+        return 0;
+    }
+    e->event_type    = EVENT_SYS_ENTER;
+    e->pid           = current_pid;
+    e->syscall_id    = (u64)syscall_id;
+    e->stack_trace_id = 0;   // unused in app-mode
+    e->kernel_ts     = bpf_ktime_get_ns();
+    bpf_ringbuf_submit(e, 0);
+    return 0;
+
+#else  /* package-mode hot path */
 
     // ---- Fix 1b: callsite pre-filter -----------------------------------
     // Read user RIP + RSP from pt_regs — two register reads, no stack walk.
@@ -203,17 +245,6 @@ int trace_syscall_enter(struct trace_event_raw_sys_enter *ctx) {
         u64 *fails = bpf_map_lookup_elem(&probe_stats, &fail_key);
         if (fails) __sync_fetch_and_add(fails, 1);
     }
-    
-    // Clean up temp maps
-    bpf_map_delete_elem(&temp_stack_ids, &tgid);
-    bpf_map_delete_elem(&temp_exec_paths, &tgid);
-    return 0;
-}
-
-
-// -----------------------------------------------------------------------------
-// 2. INSTRUMENTATION LOGIC (High Frequency / Hot Path)
-// -----------------------------------------------------------------------------
 
     // Reserve ring buffer and emit event.
     struct event *e = bpf_ringbuf_reserve(&events, sizeof(struct event), 0);
@@ -251,11 +282,14 @@ int trace_syscall_enter(struct trace_event_raw_sys_enter *ctx) {
 
     bpf_ringbuf_submit(e, 0);
     return 0;
+#endif  /* GOLEASH_APP_MODE */
 }
 
 
-
-
+#ifndef GOLEASH_APP_MODE
+// sys_exit is package-mode only: it exists to recover exec_path + stack_id
+// stashed during execve. App-mode does not track spawned binaries, so this
+// handler is omitted from the app-mode .o (loader skips its attach too).
 SEC("tracepoint/raw_syscalls/sys_exit")
 int trace_syscall_exit(struct trace_event_raw_sys_exit *ctx) {
 
@@ -269,8 +303,6 @@ int trace_syscall_exit(struct trace_event_raw_sys_exit *ctx) {
     if (ctx->id != SYS_execve && ctx->id != SYS_execveat) {
         return 0;
     }
-
-    // bpf_printk("DEBUG: Execve EXIT caught for PID %d", pid);
 
     struct event *e = bpf_ringbuf_reserve(&events, sizeof(struct event), 0);
     if (!e) return 0;
@@ -295,9 +327,10 @@ int trace_syscall_exit(struct trace_event_raw_sys_exit *ctx) {
         bpf_map_delete_elem(&temp_exec_paths, &pid);
     }
 
-    bpf_ringbuf_submit(e, 0);        
+    bpf_ringbuf_submit(e, 0);
     return 0;
 }
+#endif  /* !GOLEASH_APP_MODE */
 
 
 /* example of sending a sigterm to the traced process

--- a/goleash/include/trace.bpf.h
+++ b/goleash/include/trace.bpf.h
@@ -83,14 +83,6 @@ struct {
 	__uint(max_entries, 1 << 24);
 } events SEC(".maps");
 
-// Stack trace storage
-struct {
-    __uint(type, BPF_MAP_TYPE_STACK_TRACE);
-    __uint(key_size, sizeof(u32));
-    __uint(value_size, MAX_STACK_DEPTH * sizeof(u64));
-    __uint(max_entries, 10000);
-} stacktraces SEC(".maps");
-
 // Target process tracking.
 //
 // A small BPF_MAP_TYPE_HASH keyed by TGID. We tried BPF_MAP_TYPE_TASK_STORAGE
@@ -106,6 +98,19 @@ struct {
     __type(key, u32);
     __type(value, u8);
 } tracked_pids_map SEC(".maps");
+
+#ifndef GOLEASH_APP_MODE
+// ============================================================================
+// PACKAGE-MODE MAPS — disabled in app-mode (minimum-overhead build).
+// ============================================================================
+
+// Stack trace storage (consumed by bpf_get_stackid → resolved by userspace).
+struct {
+    __uint(type, BPF_MAP_TYPE_STACK_TRACE);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, MAX_STACK_DEPTH * sizeof(u64));
+    __uint(max_entries, 10000);
+} stacktraces SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
@@ -166,6 +171,28 @@ struct {
     __type(key, struct callsite_key);
     __type(value, u8);
 } callsite_seen SEC(".maps");
+
+#else  /* GOLEASH_APP_MODE */
+// ============================================================================
+// APP-MODE MAP — single dedup keyed by (tgid, syscall_id).
+// ============================================================================
+// No stack walking, no callsite pre-filter, no execve special-casing.
+// Once a (tgid, syscall_id) pair has been admitted, every subsequent syscall
+// with the same pair short-circuits at the BPF lookup. Userspace coalesces
+// per-binary via its tgid -> comm cache.
+struct app_seen_key {
+    u32 tgid;
+    u32 syscall_id;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_PERCPU_HASH);
+    __uint(max_entries, 16384);
+    __type(key, struct app_seen_key);
+    __type(value, u8);
+} app_seen SEC(".maps");
+
+#endif  /* GOLEASH_APP_MODE */
 
 const struct event *unused __attribute__((unused));
 

--- a/goleash/main.go
+++ b/goleash/main.go
@@ -16,6 +16,7 @@ import (
 )
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -type event ebpf backend.c
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -type event -cflags "-DGOLEASH_APP_MODE" -type app_seen_key ebpfApp backend.c
 
 type RuntimeConfig struct {
 	BinaryPaths []string
@@ -39,7 +40,7 @@ func main() {
 	var binaryPaths string
 
 	flag.StringVar(&binaryPaths, "binary", "", "Comma-separated list of paths to binaries for syscall tracking")
-	flag.StringVar(&config.Mode, "mode", "build", "Execution mode: 'build', 'sys-enforce', 'cap-enforce'")
+	flag.StringVar(&config.Mode, "mode", "build", "Execution mode: 'build', 'build-app', 'sys-enforce', 'cap-enforce'")
 	flag.Parse()
 
 	config.BinaryPaths = strings.Split(binaryPaths, ",")
@@ -52,6 +53,7 @@ func main() {
 
 	modes := map[string]func(RuntimeConfig){
 		"build":       runBuildMode,
+		"build-app":   runBuildAppMode,
 		"sys-enforce": runSysEnforceMode,
 		"cap-enforce": runCapabilityEnforceMode,
 	}
@@ -59,8 +61,48 @@ func main() {
 	if fn, exists := modes[config.Mode]; exists {
 		fn(config)
 	} else {
-		log.Fatalf("Invalid mode: %s. Use 'build', 'sys-enforce', 'cap-enforce'", config.Mode)
+		log.Fatalf("Invalid mode: %s. Use 'build', 'build-app', 'sys-enforce', 'cap-enforce'", config.Mode)
 	}
+}
+
+// runBuildAppMode is the application-level build variant: no stack capture,
+// no package attribution. The BPF probe (compiled with -DGOLEASH_APP_MODE)
+// emits one event per (tgid, syscall_id) pair; this consumer rolls them up
+// to a per-binary syscall set in app_tracestore.json. Used to measure the
+// minimum eBPF overhead a goleash-like tool can achieve while still
+// capturing every syscall a target binary issues.
+func runBuildAppMode(args RuntimeConfig) {
+	syscalls := make(map[string]map[int]bool)
+
+	setupAndRunApp(args.BinaryPaths, func(event ebpfAppEvent) {
+		execComm := getProcessName(event.Pid)
+		if execComm == "" {
+			return
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		if _, ok := syscalls[execComm]; !ok {
+			syscalls[execComm] = make(map[int]bool)
+		}
+		syscalls[execComm][int(event.SyscallId)] = true
+	})
+
+	out := make(map[string][]int, len(syscalls))
+	for comm, set := range syscalls {
+		ids := make([]int, 0, len(set))
+		for id := range set {
+			ids = append(ids, id)
+		}
+		out[comm] = ids
+	}
+
+	if err := syscallfilter.WriteAppTraceStore(out); err != nil {
+		log.Fatalf("Writing app trace store: %v", err)
+	}
+
+	log.Println("Build-app mode completed. app_tracestore.json created.")
 }
 
 func runBuildMode(args RuntimeConfig) {

--- a/goleash/syscallfilter/app_syscalls.go
+++ b/goleash/syscallfilter/app_syscalls.go
@@ -1,0 +1,57 @@
+package syscallfilter
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+)
+
+// AppTraceEntry is the application-level allowlist entry: per-binary syscall
+// and capability sets, with no per-package attribution or call-stack data.
+// Used by `-mode build-app` runs of the eBPF probe.
+type AppTraceEntry struct {
+	Binary       string   `json:"binary"`
+	Syscalls     []int    `json:"syscalls"`
+	Capabilities []string `json:"capabilities"`
+}
+
+// AppTraceStore maps comm (binary name) to its admitted-syscall set.
+type AppTraceStore map[string]*AppTraceEntry
+
+// WriteAppTraceStore persists a comm -> syscall-ids map to
+// app_tracestore.json, merging with any existing file so repeated build-app
+// runs accumulate coverage.
+func WriteAppTraceStore(perBinary map[string][]int) error {
+	existing := readOrCreateAppTraceStore()
+
+	for comm, ids := range perBinary {
+		entry, ok := existing[comm]
+		if !ok {
+			entry = &AppTraceEntry{Binary: comm}
+			existing[comm] = entry
+		}
+		entry.Syscalls = mergeUniqueInts(entry.Syscalls, ids)
+	}
+
+	for _, entry := range existing {
+		sort.Ints(entry.Syscalls)
+		entry.Capabilities = getUniqueCapabilities(entry.Syscalls)
+	}
+
+	data, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling app trace data: %v", err)
+	}
+	return os.WriteFile(appTraceStoreFile, data, filePermissions)
+}
+
+func readOrCreateAppTraceStore() AppTraceStore {
+	store := make(AppTraceStore)
+	if _, err := os.Stat(appTraceStoreFile); err == nil {
+		if data, err := os.ReadFile(appTraceStoreFile); err == nil {
+			_ = json.Unmarshal(data, &store)
+		}
+	}
+	return store
+}

--- a/goleash/syscallfilter/constants.go
+++ b/goleash/syscallfilter/constants.go
@@ -1,8 +1,9 @@
 package syscallfilter
 
 const (
-	traceStoreFile  = "tracestore.json"
-	filePermissions = 0644
+	traceStoreFile    = "tracestore.json"
+	appTraceStoreFile = "app_tracestore.json"
+	filePermissions   = 0644
 )
 
 //	: "CAP_WRITE_FILE", 		//	open("/path/to/file", O_WRONLY)

--- a/goleash/utils_app.go
+++ b/goleash/utils_app.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/ringbuf"
+	"github.com/cilium/ebpf/rlimit"
+	"golang.org/x/sys/unix"
+)
+
+// loadEBPFApp attaches only the tracepoints needed by app-mode.
+// No raw_syscalls/sys_exit (no execve special-casing); no stacktrace map.
+func loadEBPFApp() (*ebpfAppObjects, *ringbuf.Reader, []link.Link, error) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return nil, nil, nil, fmt.Errorf("removing memlock: %w", err)
+	}
+
+	objs := ebpfAppObjects{}
+	if err := loadEbpfAppObjects(&objs, nil); err != nil {
+		return nil, nil, nil, fmt.Errorf("loading objects: %w", err)
+	}
+
+	var tps []link.Link
+
+	tpEnter, err := link.Tracepoint("raw_syscalls", "sys_enter", objs.TraceSyscallEnter, nil)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("opening sys_enter tracepoint: %w", err)
+	}
+	tps = append(tps, tpEnter)
+
+	tpExec, err := link.Tracepoint("sched", "sched_process_exec", objs.TraceExecEvent, nil)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("opening sched_process_exec tracepoint: %w", err)
+	}
+	tps = append(tps, tpExec)
+
+	tpFork, err := link.AttachTracing(link.TracingOptions{Program: objs.TraceFork})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("attaching tp_btf sched_process_fork: %w", err)
+	}
+	tps = append(tps, tpFork)
+
+	tpProcessExit, err := link.Tracepoint("sched", "sched_process_exit", objs.TraceExit, nil)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("opening sched_process_exit tracepoint: %w", err)
+	}
+	tps = append(tps, tpProcessExit)
+
+	rd, err := ringbuf.NewReader(objs.Events)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("opening ringbuf reader: %w", err)
+	}
+
+	return &objs, rd, tps, nil
+}
+
+// setupAndRunApp is the app-mode counterpart of setupAndRun. No
+// binanalyzer.LoadBinarySymbolsCache, no per-event stack cache, no stack
+// resolution. The probe emits one event per (tgid, syscall_id) pair; this
+// loop just routes it to the caller for per-binary aggregation.
+func setupAndRunApp(binaryPaths []string, processEvent func(ebpfAppEvent)) {
+	objs, rd, tps, err := loadEBPFApp()
+	if err != nil {
+		log.Fatalf("Setting up eBPF (app mode): %v", err)
+	}
+	defer objs.Close()
+	defer rd.Close()
+	for _, tp := range tps {
+		defer tp.Close()
+	}
+
+	stopChan := make(chan os.Signal, 1)
+	signal.Notify(stopChan, os.Interrupt, syscall.SIGTERM)
+
+	log.Println("\nTracking syscalls (app mode — no stack capture)")
+	log.Println("List of binaries being tracked...")
+	for _, path := range binaryPaths {
+		fmt.Println(path)
+	}
+
+	var (
+		eventsProcessed   atomic.Int64
+		maxLagNs          atomic.Int64
+		processEventNsSum atomic.Int64
+	)
+
+	var monoTs unix.Timespec
+	unix.ClockGettime(unix.CLOCK_MONOTONIC, &monoTs)
+	monoToRealOffsetNs := time.Now().UnixNano() - (monoTs.Sec*int64(time.Second) + int64(monoTs.Nsec))
+
+	doneChan := make(chan struct{})
+
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		var lastCount int64
+		for {
+			select {
+			case <-doneChan:
+				return
+			case <-ticker.C:
+				current := eventsProcessed.Load()
+				rate := (current - lastCount) / 5
+				lastCount = current
+				maxLag := time.Duration(maxLagNs.Swap(0))
+				log.Printf("[metrics] consumer (app): %d events/s | max lag: %v", rate, maxLag)
+			}
+		}
+	}()
+
+	go func() {
+		var event ebpfAppEvent
+		for {
+			select {
+			case <-stopChan:
+				log.Println("Received signal, stopping syscall tracking...")
+				return
+			default:
+				record, err := rd.Read()
+				if err != nil {
+					if errors.Is(err, ringbuf.ErrClosed) {
+						return
+					}
+					log.Printf("Reading from reader: %s", err)
+					continue
+				}
+
+				if err := binary.Read(bytes.NewBuffer(record.RawSample), binary.LittleEndian, &event); err != nil {
+					log.Printf("Parsing ringbuf event: %s", err)
+					continue
+				}
+
+				if event.EventType == EventTrackStart {
+					updateProcessNameApp(event.Pid, unsafe.Pointer(&event.Payload))
+					continue
+				}
+
+				eventsProcessed.Add(1)
+
+				if event.KernelTs > 0 {
+					lagNs := time.Now().UnixNano() - (int64(event.KernelTs) + monoToRealOffsetNs)
+					if lagNs > maxLagNs.Load() {
+						maxLagNs.Store(lagNs)
+					}
+				}
+
+				peStart := time.Now()
+				processEvent(event)
+				processEventNsSum.Add(time.Since(peStart).Nanoseconds())
+			}
+		}
+	}()
+
+	<-stopChan
+	close(doneChan)
+
+	// probe_stats schema is identical to package mode (3 PERCPU counters):
+	//   index 0 = ringbuf_drops
+	//   index 1 = stackid_failures (always 0 in app-mode — no stack walks)
+	//   index 2 = enter_admitted   (here: unique (tgid, syscall_id) pairs)
+	statLabels := []string{"ringbuf_drops", "stackid_failures", "enter_admitted"}
+	stats := make(map[string]uint64, len(statLabels))
+	perCPU := make([]uint64, 0)
+	for i, label := range statLabels {
+		if err := objs.ProbeStats.Lookup(uint32(i), &perCPU); err == nil {
+			var sum uint64
+			for _, v := range perCPU {
+				sum += v
+			}
+			stats[label] = sum
+			log.Printf("[probe_stats] %s: %d", label, sum)
+		}
+	}
+
+	consumed := eventsProcessed.Load()
+	peSumNs := processEventNsSum.Load()
+	var avgPeNs int64
+	if consumed > 0 {
+		avgPeNs = peSumNs / consumed
+	}
+	log.Printf("[probe_stats] consumer_total_processed: %d", consumed)
+	log.Printf("[probe_stats] processEvent_total_ns: %d (avg %d ns/event)", peSumNs, avgPeNs)
+
+	dump := map[string]interface{}{
+		"timestamp_unix":           time.Now().Unix(),
+		"mode":                     "app",
+		"ringbuf_drops":            stats["ringbuf_drops"],
+		"stackid_failures":         stats["stackid_failures"],
+		"enter_admitted":           stats["enter_admitted"],
+		"seen_pairs_unique":        uint64(0),
+		"consumer_total_processed": consumed,
+		"process_event_total_ns":   peSumNs,
+		"process_event_avg_ns":     avgPeNs,
+		"stack_cache_hits":         uint64(0),
+		"stack_cache_misses":       uint64(0),
+	}
+	if data, err := json.MarshalIndent(dump, "", "  "); err == nil {
+		if err := os.WriteFile("probe_stats.json", data, 0o644); err != nil {
+			log.Printf("[probe_stats] failed to write probe_stats.json: %v", err)
+		}
+	}
+}
+
+// updateProcessNameApp reads comm out of the ebpfApp payload union. bpf2go
+// generates a distinct payload type per .o, so we take an unsafe.Pointer to
+// the payload region and read the first 16 bytes (the comm prefix of the
+// 256-byte union).
+func updateProcessNameApp(pid uint32, payloadPtr unsafe.Pointer) {
+	raw := (*[256]byte)(payloadPtr)[:16]
+	name := unix.ByteSliceToString(raw)
+	commCacheMu.Lock()
+	commCache[pid] = name
+	commCacheMu.Unlock()
+}


### PR DESCRIPTION
Compile-time -DGOLEASH_APP_MODE produces a second BPF object (ebpfapp_*) that drops stack capture, callsite pre-filter, and execve special-casing. Dedup on (tgid, syscall_id) admits each pair once; userspace coalesces per-binary via the tgid→comm cache. Trade-off: no per-package attribution.

Kernel (backend.c, trace.bpf.h):
- New app_seen LRU PERCPU map (tgid + syscall_id key).
- Package-mode maps and the trace_syscall_enter hot path, trace_syscall_exit, and execve cleanup gated by #ifdef GOLEASH_APP_MODE.

Loader (Go):
- Second //go:generate emits ebpfApp* bindings; both .o embed into the same bpf_loader binary.
- -mode build-app runs setupAndRunApp (no symbol cache, no stack resolution) and writes app_tracestore.json keyed by binary comm.

Makefile clean rule extended for ebpfapp_*.